### PR TITLE
docs(broke-star-link): Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ Claude Code PM was developed at [Automaze](https://automaze.io) **for developers
 
 If Claude Code PM helps your team ship better software:
 
-- ⭐ **[Star this repository](https://github.com/your-username/claude-code-pm)** to show your support
+- ⭐ **[Star this repository](https://github.com/automazeio/ccpm)** to show your support
 - 🐦 **[Follow @aroussi on X](https://x.com/aroussi)** for updates and tips
 
 


### PR DESCRIPTION
Update broken star link for ccpm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to point the “Star this repository” link to the correct GitHub repo (automazeio/ccpm).
  * Enhances accuracy of project links and reduces confusion when bookmarking or sharing.
  * Users can now easily star the correct project directly from the README.
  * No behavior or API changes; no setup, build, or runtime impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->