### PR TITLE
Fix path to install script in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,14 +388,14 @@ Teams using this system report:
 
    ```bash
    cd path/to/your/project/
-   curl -sSL https://raw.githubusercontent.com/automazeio/ccpm/main/ccpm.sh | bash
-   # or: wget -qO- https://raw.githubusercontent.com/automazeio/ccpm/main/ccpm.sh | bash
+   curl -sSL https://raw.githubusercontent.com/automazeio/ccpm/main/install/ccpm.sh | bash
+   # or: wget -qO- https://raw.githubusercontent.com/automazeio/ccpm/main/install/ccpm.sh | bash
    ```
 
    #### Windows (PowerShell)
    ```bash
    cd path/to/your/project/
-   iwr -useb https://raw.githubusercontent.com/automazeio/ccpm/main/ccpm.bat | iex
+   iwr -useb https://raw.githubusercontent.com/automazeio/ccpm/main/install/ccpm.bat | iex
    ```
    > ⚠️ **IMPORTANT**: If you already have a `.claude` directory, clone this repository to a different directory and copy the contents of the cloned `.claude` directory to your project's `.claude` directory.
 

--- a/install/README.md
+++ b/install/README.md
@@ -3,25 +3,25 @@
 ## Unix/Linux/macOS
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/automazeio/ccpm/main/ccpm.sh | bash
+curl -sSL https://raw.githubusercontent.com/automazeio/ccpm/main/install/ccpm.sh | bash
 ```
 
 Or with wget:
 
 ```bash
-wget -qO- https://raw.githubusercontent.com/automazeio/ccpm/main/ccpm.sh | bash
+wget -qO- https://raw.githubusercontent.com/automazeio/ccpm/main/install/ccpm.sh | bash
 ```
 
 ## Windows (PowerShell)
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/automazeio/ccpm/main/ccpm.bat | iex
+iwr -useb https://raw.githubusercontent.com/automazeio/ccpm/main/install/ccpm.bat | iex
 ```
 
 Or download and execute:
 
 ```powershell
-curl -o ccpm.bat https://raw.githubusercontent.com/automazeio/ccpm/main/ccpm.bat && ccpm.bat
+curl -o ccpm.bat https://raw.githubusercontent.com/automazeio/ccpm/main/install/ccpm.bat && ccpm.bat
 ```
 
 ## One-liner alternatives


### PR DESCRIPTION
This PR corrects the installation script path in documentation to point to the correct location in the repository.

Changes:
- Updated ccpm.sh path from main/ccpm.sh to main/install/ccpm.sh in main README.md installation instructions
- Updated ccpm.bat path from main/ccpm.bat to main/install/ccpm.bat in main README.md installation instructions
- Updated corresponding paths in install/README.md for both curl and wget commands

The install script was moved to the install/ directory but the documentation still referenced the old root location, causing 404 errors for users trying to install via the provided commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation commands to point to the installer in the repo's install directory for Unix/Linux/macOS (curl/wget) and for Windows PowerShell.
  * Aligned instructions across docs for consistency and reduced setup friction for shell- and PowerShell-based installs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->