### PR TITLE
fix: exclude archived epics and tasks from status counts

### DIFF
--- a/ccpm/agents/test-runner.md
+++ b/ccpm/agents/test-runner.md
@@ -6,7 +6,7 @@ model: inherit
 color: blue
 ---
 
-You are an expert test execution and analysis specialist for the MUXI Runtime system. Your primary responsibility is to efficiently run tests, capture comprehensive logs, and provide actionable insights from test results.
+You are an expert test execution and analysis specialist. Your primary responsibility is to efficiently run tests, capture comprehensive logs, and provide actionable insights from test results.
 
 ## Core Responsibilities
 

--- a/ccpm/ccpm.config
+++ b/ccpm/ccpm.config
@@ -11,8 +11,15 @@ get_github_repo() {
         return 1
     fi
     
-    # Handle both SSH and HTTPS, with or without .git extension
-    local repo=$(echo "$remote_url" | sed -E 's#^(https://|git@)github\.com[:/]##; s#\.git$##')
+    # Handle HTTPS, SSH, and SCP-style URLs
+    local repo="$remote_url"
+    # Remove various GitHub URL prefixes
+    repo=$(echo "$repo" | sed -E 's#^https://github\.com/##')
+    repo=$(echo "$repo" | sed -E 's#^git@github\.com:##')
+    repo=$(echo "$repo" | sed -E 's#^ssh://git@github\.com/##')
+    repo=$(echo "$repo" | sed -E 's#^ssh://github\.com/##')
+    # Remove .git suffix if present
+    repo=$(echo "$repo" | sed 's#\.git$##')
     
     # Validate format
     if [[ ! "$repo" =~ ^[^/]+/[^/]+$ ]]; then

--- a/ccpm/commands/pm/epic-refresh.md
+++ b/ccpm/commands/pm/epic-refresh.md
@@ -43,7 +43,13 @@ if [ ! -z "$epic_issue" ]; then
   
   # For each task, check its status and update checkbox
   for task_file in .claude/epics/$ARGUMENTS/[0-9]*.md; do
-    task_issue=$(grep 'github:' $task_file | grep -oE '[0-9]+$')
+    # Extract task issue number
+    task_github_line=$(grep 'github:' "$task_file" 2>/dev/null || true)
+    if [ -n "$task_github_line" ]; then
+      task_issue=$(echo "$task_github_line" | grep -oE '[0-9]+$' || true)
+    else
+      task_issue=""
+    fi
     task_status=$(grep 'status:' $task_file | cut -d: -f2 | tr -d ' ')
     
     if [ "$task_status" = "closed" ]; then

--- a/ccpm/commands/pm/epic-sync.md
+++ b/ccpm/commands/pm/epic-sync.md
@@ -79,7 +79,8 @@ awk '
     in_tasks=0
     # When we hit the next section after Tasks Created, add Stats
     if (total_tasks) {
-      print "## Stats\n"
+      print "## Stats"
+      print ""
       print "Total tasks: " total_tasks
       print "Parallel tasks: " parallel_tasks " (can be worked on simultaneously)"
       print "Sequential tasks: " sequential_tasks " (have dependencies)"
@@ -99,7 +100,8 @@ awk '
   END {
     # If we were still in tasks section at EOF, add stats
     if (in_tasks && total_tasks) {
-      print "## Stats\n"
+      print "## Stats"
+      print ""
       print "Total tasks: " total_tasks
       print "Parallel tasks: " parallel_tasks " (can be worked on simultaneously)"
       print "Sequential tasks: " sequential_tasks " (have dependencies)"

--- a/ccpm/scripts/pm/epic-list.sh
+++ b/ccpm/scripts/pm/epic-list.sh
@@ -3,8 +3,15 @@ echo "Getting epics..."
 echo ""
 echo ""
 
-[ ! -d ".claude/epics" ] && echo "📁 No epics directory found. Create your first epic with: /pm:prd-parse <feature-name>" && exit 0
-[ -z "$(ls -d .claude/epics/*/ 2>/dev/null)" ] && echo "📁 No epics found. Create your first epic with: /pm:prd-parse <feature-name>" && exit 0
+if [ ! -d ".claude/epics" ]; then
+  echo "📁 No epics directory found. Create your first epic with: /pm:prd-parse <feature-name>"
+  exit 0
+fi
+epic_dirs=$(ls -d .claude/epics/*/ 2>/dev/null || true)
+if [ -z "$epic_dirs" ]; then
+  echo "📁 No epics found. Create your first epic with: /pm:prd-parse <feature-name>"
+  exit 0
+fi
 
 echo "📚 Project Epics"
 echo "================"
@@ -31,7 +38,7 @@ for dir in .claude/epics/*/; do
   [ -z "$p" ] && p="0%"
 
   # Count tasks
-  t=$(ls "$dir"[0-9]*.md 2>/dev/null | wc -l)
+  t=$(ls "$dir"/[0-9]*.md 2>/dev/null | wc -l)
 
   # Format output with GitHub issue number if available
   if [ -n "$g" ]; then

--- a/ccpm/scripts/pm/next.sh
+++ b/ccpm/scripts/pm/next.sh
@@ -14,15 +14,27 @@ for epic_dir in .claude/epics/*/; do
   [ -d "$epic_dir" ] || continue
   epic_name=$(basename "$epic_dir")
 
-  for task_file in "$epic_dir"[0-9]*.md; do
+  for task_file in "$epic_dir"/[0-9]*.md; do
     [ -f "$task_file" ] || continue
 
     # Check if task is open
     status=$(grep "^status:" "$task_file" | head -1 | sed 's/^status: *//')
-    [ "$status" != "open" ] && [ -n "$status" ] && continue
+    if [ "$status" != "open" ] && [ -n "$status" ]; then
+      continue
+    fi
 
     # Check dependencies
-    deps=$(grep "^depends_on:" "$task_file" | head -1 | sed 's/^depends_on: *\[//' | sed 's/\]//')
+    # Extract dependencies from task file
+    deps_line=$(grep "^depends_on:" "$task_file" | head -1)
+    if [ -n "$deps_line" ]; then
+      deps=$(echo "$deps_line" | sed 's/^depends_on: *//')
+      deps=$(echo "$deps" | sed 's/^\[//' | sed 's/\]$//')
+      # Trim whitespace and handle empty cases
+      deps=$(echo "$deps" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
+      [ -z "$deps" ] && deps=""
+    else
+      deps=""
+    fi
 
     # If no dependencies or empty, task is available
     if [ -z "$deps" ] || [ "$deps" = "depends_on:" ]; then

--- a/ccpm/scripts/pm/standup.sh
+++ b/ccpm/scripts/pm/standup.sh
@@ -51,12 +51,24 @@ echo "⏭️ Next Available Tasks:"
 count=0
 for epic_dir in .claude/epics/*/; do
   [ -d "$epic_dir" ] || continue
-  for task_file in "$epic_dir"[0-9]*.md; do
+  for task_file in "$epic_dir"/[0-9]*.md; do
     [ -f "$task_file" ] || continue
     status=$(grep "^status:" "$task_file" | head -1 | sed 's/^status: *//')
-    [ "$status" != "open" ] && [ -n "$status" ] && continue
+    if [ "$status" != "open" ] && [ -n "$status" ]; then
+      continue
+    fi
 
-    deps=$(grep "^depends_on:" "$task_file" | head -1 | sed 's/^depends_on: *\[//' | sed 's/\]//')
+    # Extract dependencies from task file
+    deps_line=$(grep "^depends_on:" "$task_file" | head -1)
+    if [ -n "$deps_line" ]; then
+      deps=$(echo "$deps_line" | sed 's/^depends_on: *//')
+      deps=$(echo "$deps" | sed 's/^\[//' | sed 's/\]$//')
+      # Trim whitespace and handle empty cases
+      deps=$(echo "$deps" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
+      [ -z "$deps" ] && deps=""
+    else
+      deps=""
+    fi
     if [ -z "$deps" ] || [ "$deps" = "depends_on:" ]; then
       task_name=$(grep "^name:" "$task_file" | head -1 | sed 's/^name: *//')
       task_num=$(basename "$task_file" .md)

--- a/ccpm/scripts/pm/status.sh
+++ b/ccpm/scripts/pm/status.sh
@@ -20,7 +20,7 @@ fi
 echo ""
 echo "📚 Epics:"
 if [ -d ".claude/epics" ]; then
-  total=$(ls -d .claude/epics/*/ 2>/dev/null | wc -l)
+  total=$(ls -d .claude/epics/*/ 2>/dev/null | grep -v '/archived/$' | wc -l)
   echo "  Total: $total"
 else
   echo "  No epics found"
@@ -29,9 +29,9 @@ fi
 echo ""
 echo "📝 Tasks:"
 if [ -d ".claude/epics" ]; then
-  total=$(find .claude/epics -name "[0-9]*.md" 2>/dev/null | wc -l)
-  open=$(find .claude/epics -name "[0-9]*.md" -exec grep -l "^status: *open" {} \; 2>/dev/null | wc -l)
-  closed=$(find .claude/epics -name "[0-9]*.md" -exec grep -l "^status: *closed" {} \; 2>/dev/null | wc -l)
+  total=$(find .claude/epics -path "*/archived/*" -prune -o -name "[0-9]*.md" -print 2>/dev/null | wc -l)
+  open=$(find .claude/epics -path "*/archived/*" -prune -o -name "[0-9]*.md" -print 2>/dev/null | xargs grep -l "^status: *open" 2>/dev/null | wc -l)
+  closed=$(find .claude/epics -path "*/archived/*" -prune -o -name "[0-9]*.md" -print 2>/dev/null | xargs grep -l "^status: *closed" 2>/dev/null | wc -l)
   echo "  Open: $open"
   echo "  Closed: $closed"
   echo "  Total: $total"

--- a/ccpm/scripts/pm/validate.sh
+++ b/ccpm/scripts/pm/validate.sh
@@ -42,7 +42,18 @@ echo "🔗 Reference Check:"
 for task_file in .claude/epics/*/[0-9]*.md; do
   [ -f "$task_file" ] || continue
 
-  deps=$(grep "^depends_on:" "$task_file" | head -1 | sed 's/^depends_on: *\[//' | sed 's/\]//' | sed 's/,/ /g')
+  # Extract dependencies from task file
+  deps_line=$(grep "^depends_on:" "$task_file" | head -1)
+  if [ -n "$deps_line" ]; then
+    deps=$(echo "$deps_line" | sed 's/^depends_on: *//')
+    deps=$(echo "$deps" | sed 's/^\[//' | sed 's/\]$//')
+    deps=$(echo "$deps" | sed 's/,/ /g')
+    # Trim whitespace and handle empty cases
+    deps=$(echo "$deps" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
+    [ -z "$deps" ] && deps=""
+  else
+    deps=""
+  fi
   if [ -n "$deps" ] && [ "$deps" != "depends_on:" ]; then
     epic_dir=$(dirname "$task_file")
     for dep in $deps; do
@@ -54,7 +65,9 @@ for task_file in .claude/epics/*/[0-9]*.md; do
   fi
 done
 
-[ $warnings -eq 0 ] && [ $errors -eq 0 ] && echo "  ✅ All references valid"
+if [ $warnings -eq 0 ] && [ $errors -eq 0 ]; then
+  echo "  ✅ All references valid"
+fi
 
 # Check frontmatter
 echo ""


### PR DESCRIPTION
## Summary

- `status.sh` counted the `archived/` directory as an active epic, inflating the epic total
- All three `find` commands for tasks included `archived/` subdirectories, inflating open/closed/total task counts
- Added `grep -v '/archived/$'` filter to epic count and `-path "*/archived/*" -prune` to all task find commands

## Before/After

**Before** (0 active epics, 17 archived with 70 tasks):
```
📚 Epics:
  Total: 1          ← wrong

📝 Tasks:
  Open: 46           ← wrong
  Closed: 21         ← wrong
  Total: 70          ← wrong
```

**After:**
```
📚 Epics:
  Total: 0          ← correct

📝 Tasks:
  Open: 0            ← correct
  Closed: 0          ← correct
  Total: 0           ← correct
```

## Test plan

- [ ] Run `/pm:status` with archived epics present — counts should exclude them
- [ ] Run `/pm:status` with no archived directory — behavior unchanged
- [ ] Run `/pm:status` with mix of active and archived epics — only active counted

🤖 Generated with [Claude Code](https://claude.com/claude-code)