### PR TITLE
fix: ignore archived epics in validate + add Hermes bridge mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,23 @@ In your project root, add a `skills/` directory and symlink or copy the skill:
 ln -s /path/to/ccpm/skill/ccpm .claude/skills/ccpm
 ```
 
+### Hermes Agent (bridge mode)
+
+CCPM's scripts expect a `.claude/` project layout. In Hermes, you can keep state under `.hermes/ccpm/` and create a compatibility bridge:
+
+```bash
+# from your project root
+/path/to/ccpm/skill/ccpm/references/scripts/hermes-bridge.sh
+```
+
+That creates `.hermes/ccpm/{prds,epics,rules,...}` and a symlink:
+
+```bash
+.claude -> .hermes/ccpm
+```
+
+Then install the skill in your Hermes skills path as usual.
+
 ### Any other Agent Skills–compatible harness
 
 Point it at `skill/ccpm/`. It follows the [agentskills.io](https://agentskills.io) standard and works out of the box.

--- a/skill/ccpm/references/scripts/hermes-bridge.sh
+++ b/skill/ccpm/references/scripts/hermes-bridge.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+# Bridge CCPM's default .claude layout to a Hermes-native state directory.
+# Usage:
+#   ./hermes-bridge.sh                    # uses .hermes/ccpm
+#   ./hermes-bridge.sh .hermes/my-ccpm    # custom state dir
+
+STATE_DIR="${1:-.hermes/ccpm}"
+
+mkdir -p "$STATE_DIR"/{prds,epics,rules,agents,scripts/pm}
+
+if [ -L ".claude" ]; then
+  current_target="$(readlink .claude)"
+  if [ "$current_target" = "$STATE_DIR" ]; then
+    echo "✅ .claude already points to $STATE_DIR"
+  else
+    echo "⚠️ .claude is already a symlink to '$current_target'"
+    echo "   Update manually if you want it to point to '$STATE_DIR'."
+  fi
+elif [ -e ".claude" ]; then
+  echo "⚠️ .claude exists as a real directory/file. Leaving it unchanged."
+  echo "   If you want Hermes bridge mode, move it first, then run again."
+else
+  ln -s "$STATE_DIR" .claude
+  echo "✅ Created symlink: .claude -> $STATE_DIR"
+fi
+
+echo ""
+echo "Hermes bridge status:"
+echo "  State dir: $STATE_DIR"
+if [ -L .claude ]; then
+  echo "  .claude -> $(readlink .claude)"
+else
+  echo "  .claude is not a symlink"
+fi

--- a/skill/ccpm/references/scripts/validate.sh
+++ b/skill/ccpm/references/scripts/validate.sh
@@ -22,11 +22,14 @@ echo ""
 # Check for orphaned files
 echo "🗂️ Data Integrity:"
 
-# Check epics have epic.md files
+# Check epics have epic.md files (ignore archive buckets)
 for epic_dir in .claude/epics/*/; do
   [ -d "$epic_dir" ] || continue
+  epic_name=$(basename "$epic_dir")
+  [ "$epic_name" = "archived" ] && continue
+  [ "$epic_name" = "archive" ] && continue
   if [ ! -f "$epic_dir/epic.md" ]; then
-    echo "  ⚠️ Missing epic.md in $(basename "$epic_dir")"
+    echo "  ⚠️ Missing epic.md in $epic_name"
     ((warnings++))
   fi
 done


### PR DESCRIPTION
## Summary
- ignore archive buckets (`archived` / `archive`) when validating epics for `epic.md`
- add `hermes-bridge.sh` to create `.hermes/ccpm` and symlink `.claude -> .hermes/ccpm`
- document Hermes bridge mode in README

## Validation
- ran `validate.sh` in a fixture with `.claude/epics/archived` only (no false warning)
- ran `hermes-bridge.sh` then `validate.sh` to confirm compatibility

## Why
- avoids false-positive warnings for archive buckets
- makes CCPM interoperable with Hermes state layout while preserving `.claude` compatibility
